### PR TITLE
Update to .NET 9.0 and upgrade dependencies

### DIFF
--- a/PHC-HighCounsel-Bot/Dockerfile
+++ b/PHC-HighCounsel-Bot/Dockerfile
@@ -1,10 +1,10 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:8.0 AS base
+FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
 USER app
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["PHC-HighCounsel-Bot/PHC-HighCounsel-Bot.csproj", "PHC-HighCounsel-Bot/"]

--- a/PHC-HighCounsel-Bot/PHC-HighCounsel-Bot.csproj
+++ b/PHC-HighCounsel-Bot/PHC-HighCounsel-Bot.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<RootNamespace>PHC_HighCounsel_Bot</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -15,12 +15,12 @@
         <PackageReference Include="Discord.Net" Version="3.16.0" />
 		<PackageReference Include="Discord.Net.Interactions" Version="3.16.0" />
 		<PackageReference Include="Fergun.Interactive" Version="1.8.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.0" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-        <PackageReference Include="OllamaSharp" Version="4.0.6" />
+        <PackageReference Include="OllamaSharp" Version="4.0.7" />
         <PackageReference Include="Serilog" Version="4.1.0" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />


### PR DESCRIPTION
Updated Dockerfile base and build images to .NET 9.0. Changed target framework in `PHC-HighCounsel-Bot.csproj` to `net9.0`. Upgraded several NuGet packages to version 9.0.0, including `Microsoft.Extensions.Configuration.UserSecrets`, `Microsoft.Extensions.Hosting`, `Microsoft.Extensions.Logging.Console`, and `Microsoft.Extensions.Options.DataAnnotations`. Updated `OllamaSharp` package from `4.0.6` to `4.0.7`.